### PR TITLE
fragmentへ渡すものを変更、新規登録用のUI追加

### DIFF
--- a/app/src/main/java/com/nokopi/marketregistersystem/MainActivity.kt
+++ b/app/src/main/java/com/nokopi/marketregistersystem/MainActivity.kt
@@ -4,24 +4,37 @@ import androidx.appcompat.app.AppCompatActivity
 import android.os.Bundle
 import android.util.Log
 import androidx.activity.OnBackPressedCallback
+import androidx.lifecycle.ViewModelProvider
+import com.nokopi.marketregistersystem.data.UserDatabase
 
 class MainActivity : AppCompatActivity() {
+    private lateinit var  viewModel: NFCViewModel
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
         setContentView(R.layout.activity_main)
 
+        val dataSource = UserDatabase.getInstance(this).userDatabaseDao
+        val viewModelFactory = NFCViewModelFactory(dataSource)
+        viewModel = ViewModelProvider(this, viewModelFactory)[NFCViewModel::class.java]
+
         onBackPressedDispatcher.addCallback(callback)
-        val getUserResult = intent.getBooleanExtra("getUserResult", false)
-        Log.i("getUserResult", getUserResult.toString())
+        val inputId = intent.getStringExtra("inputId")
+        val args = Bundle()
+        args.putString("inputId", inputId)
+        Log.i("getUserResult", inputId.toString())
         if (savedInstanceState == null) {
-            if (getUserResult) {
+            if (viewModel.getUserIdResult(inputId.toString())) {
+                val fragment = UserFragment()
+                fragment.arguments = args
                 supportFragmentManager.beginTransaction()
-                    .replace(R.id.container, UserFragment())
+                    .replace(R.id.container, fragment)
                     .commitNow()
             } else {
+                val fragment = SignUpFragment()
+                fragment.arguments = args
                 supportFragmentManager.beginTransaction()
-                    .replace(R.id.container, SignUpFragment())
+                    .replace(R.id.container, fragment)
                     .commitNow()
             }
         }

--- a/app/src/main/java/com/nokopi/marketregistersystem/NFCActivity.kt
+++ b/app/src/main/java/com/nokopi/marketregistersystem/NFCActivity.kt
@@ -33,7 +33,7 @@ class NFCActivity : AppCompatActivity() {
             val idm = tag.id
             tag.techList
             val mainActivityIntent = Intent(this@NFCActivity, MainActivity::class.java)
-            mainActivityIntent.putExtra("getUserResult", viewModel.getUserId(byteToHex(idm)))
+            mainActivityIntent.putExtra("getUserResult", viewModel.getUserIdResult(byteToHex(idm)))
             startActivity(mainActivityIntent)
             Log.i("onReadTag", byteToHex(idm))
         }

--- a/app/src/main/java/com/nokopi/marketregistersystem/NFCActivity.kt
+++ b/app/src/main/java/com/nokopi/marketregistersystem/NFCActivity.kt
@@ -33,7 +33,7 @@ class NFCActivity : AppCompatActivity() {
             val idm = tag.id
             tag.techList
             val mainActivityIntent = Intent(this@NFCActivity, MainActivity::class.java)
-            mainActivityIntent.putExtra("getUserResult", viewModel.getUserIdResult(byteToHex(idm)))
+            mainActivityIntent.putExtra("inputId", byteToHex(idm))
             startActivity(mainActivityIntent)
             Log.i("onReadTag", byteToHex(idm))
         }

--- a/app/src/main/java/com/nokopi/marketregistersystem/NFCViewModel.kt
+++ b/app/src/main/java/com/nokopi/marketregistersystem/NFCViewModel.kt
@@ -8,16 +8,20 @@ import kotlinx.coroutines.launch
 
 class NFCViewModel(private val database: UserDatabaseDao): ViewModel() {
 
-    fun getUserId(inputId: String): Boolean {
+    fun getUserIdResult(inputId: String): Boolean {
         var getId = ""
         viewModelScope.launch {
-            getId = database.getUserId(inputId)
+            getId = getUserId(inputId)
         }
         Log.i("nfc2", inputId)
         Log.i("getId", getId)
         Log.i("Bool", (getId == inputId).toString())
 
         return getId == inputId
+    }
+
+    private suspend fun getUserId(inputId: String): String {
+        return database.getUserId(inputId)
     }
 
 }

--- a/app/src/main/java/com/nokopi/marketregistersystem/SignUpFragment.kt
+++ b/app/src/main/java/com/nokopi/marketregistersystem/SignUpFragment.kt
@@ -1,6 +1,7 @@
 package com.nokopi.marketregistersystem
 
 import android.os.Bundle
+import android.util.Log
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
@@ -32,7 +33,8 @@ class SignUpFragment: Fragment() {
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-
+        val inputId = requireArguments().getString("inputId")
+        Log.i("inputId in SignUp", inputId.toString())
     }
 
 }

--- a/app/src/main/java/com/nokopi/marketregistersystem/SignUpFragment.kt
+++ b/app/src/main/java/com/nokopi/marketregistersystem/SignUpFragment.kt
@@ -6,11 +6,14 @@ import android.view.View
 import android.view.ViewGroup
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
+import androidx.lifecycle.ViewModelProvider
+import com.nokopi.marketregistersystem.data.UserDatabase
 import com.nokopi.marketregistersystem.databinding.FragmentSignupBinding
 
 class SignUpFragment: Fragment() {
 
     private lateinit var binding: FragmentSignupBinding
+    private lateinit var viewModel: SignUpViewModel
 
     override fun onCreateView(
         inflater: LayoutInflater,
@@ -19,6 +22,17 @@ class SignUpFragment: Fragment() {
     ): View {
         binding = DataBindingUtil.inflate(inflater, R.layout.fragment_signup, container, false)
         binding.lifecycleOwner = this
+        val application = requireNotNull(this.activity).application
+        val dataSource = UserDatabase.getInstance(application).userDatabaseDao
+        val viewModelFactory = SignUpViewModelFactory(dataSource)
+        viewModel = ViewModelProvider(this, viewModelFactory)[SignUpViewModel::class.java]
+        binding.signUpViewModel = viewModel
         return binding.root
     }
+
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+
+    }
+
 }

--- a/app/src/main/java/com/nokopi/marketregistersystem/SignUpViewModel.kt
+++ b/app/src/main/java/com/nokopi/marketregistersystem/SignUpViewModel.kt
@@ -1,0 +1,37 @@
+package com.nokopi.marketregistersystem
+
+import android.util.Log
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
+import androidx.lifecycle.ViewModel
+import com.nokopi.marketregistersystem.data.User
+import com.nokopi.marketregistersystem.data.UserDatabaseDao
+
+class SignUpViewModel(private val database: UserDatabaseDao): ViewModel() {
+
+    val userNameText: MutableLiveData<String> = MutableLiveData<String>("")
+    private val userName: LiveData<String>
+        get() = userNameText
+
+    private val _isEnabled: MutableLiveData<Boolean> = MutableLiveData<Boolean>(false)
+    val isEnabled: LiveData<Boolean>
+        get() = _isEnabled
+
+
+    fun signOnUser() {
+        Log.i("userName", userName.value.toString())
+    }
+
+    fun updateButton() {
+        val isBlank = userName.value.isNullOrBlank()
+        Log.i("isBlank", isBlank.toString())
+        _isEnabled.value = !isBlank
+    }
+
+//    var user: User
+
+    private suspend fun insert(user: User) {
+        database.insert(user)
+    }
+
+}

--- a/app/src/main/java/com/nokopi/marketregistersystem/SignUpViewModelFactory.kt
+++ b/app/src/main/java/com/nokopi/marketregistersystem/SignUpViewModelFactory.kt
@@ -1,0 +1,15 @@
+package com.nokopi.marketregistersystem
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import com.nokopi.marketregistersystem.data.UserDatabaseDao
+
+class SignUpViewModelFactory(private val dataSource: UserDatabaseDao) : ViewModelProvider.Factory {
+    @Suppress("unchecked_cast")
+    override fun <T : ViewModel> create(modelClass: Class<T>): T {
+        if (modelClass.isAssignableFrom(SignUpViewModel::class.java)) {
+            return SignUpViewModel(dataSource) as T
+        }
+        throw IllegalArgumentException("Unknown ViewModel class")
+    }
+}

--- a/app/src/main/res/layout/fragment_signup.xml
+++ b/app/src/main/res/layout/fragment_signup.xml
@@ -30,7 +30,8 @@
             android:id="@+id/user_name_layout"
             app:layout_constraintTop_toTopOf="parent"
             app:layout_constraintLeft_toLeftOf="parent"
-            app:layout_constraintRight_toRightOf="parent">
+            app:layout_constraintRight_toRightOf="parent"
+            app:endIconMode="clear_text">
 
             <com.google.android.material.textfield.TextInputEditText
                 android:layout_width="match_parent"

--- a/app/src/main/res/layout/fragment_signup.xml
+++ b/app/src/main/res/layout/fragment_signup.xml
@@ -1,8 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
-<layout xmlns:android="http://schemas.android.com/apk/res/android"
+<layout xmlns:tools="http://schemas.android.com/tools"
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto">
 
     <data>
+
+        <variable
+            name="signUpViewModel"
+            type="com.nokopi.marketregistersystem.SignUpViewModel" />
 
     </data>
 
@@ -18,6 +23,33 @@
             app:layout_constraintLeft_toLeftOf="parent"
             app:layout_constraintRight_toRightOf="parent"
             app:layout_constraintBottom_toBottomOf="parent"/>
+
+        <com.google.android.material.textfield.TextInputLayout
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"
+            android:id="@+id/user_name_layout"
+            app:layout_constraintTop_toTopOf="parent"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintRight_toRightOf="parent">
+
+            <com.google.android.material.textfield.TextInputEditText
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:id="@+id/user_name"
+                android:text="@={signUpViewModel.userNameText}"
+                android:onTextChanged="@{() -> signUpViewModel.updateButton()}"
+                android:hint="@string/user_name" />
+        </com.google.android.material.textfield.TextInputLayout>
+
+        <Button
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:id="@+id/signOnBtn"
+            android:onClick="@{() -> signUpViewModel.signOnUser()}"
+            android:enabled="@{signUpViewModel.isEnabled}"
+            app:layout_constraintTop_toBottomOf="@id/user_name_layout"
+            app:layout_constraintLeft_toLeftOf="parent"
+            app:layout_constraintRight_toRightOf="parent"/>
 
     </androidx.constraintlayout.widget.ConstraintLayout>
 </layout>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -1,3 +1,4 @@
 <resources>
     <string name="app_name">MarketRegisterSystem</string>
+    <string name="user_name">名前</string>
 </resources>


### PR DESCRIPTION
SignUp用にTextInputEditTextとボタンを追加、Fragmentを起動するときにBoolではなく、読み取ったNFCの情報を渡すように変更しました。