### PR TITLE
登録済みユーザーのNFCをタッチしてもユーザー画面に行かない問題を修正

### DIFF
--- a/app/src/main/java/com/nokopi/marketregistersystem/MainActivity.kt
+++ b/app/src/main/java/com/nokopi/marketregistersystem/MainActivity.kt
@@ -23,14 +23,19 @@ class MainActivity : AppCompatActivity() {
         val args = Bundle()
         args.putString("inputId", inputId)
         Log.i("getUserResult", inputId.toString())
-        if (savedInstanceState == null) {
-            if (viewModel.getUserIdResult(inputId.toString())) {
+
+        viewModel.getUserIdResult(inputId.toString())
+
+        viewModel.isNewUser.observe(this) {
+            if (it) {
+                Log.i("Bool in main", it.toString())
                 val fragment = UserFragment()
                 fragment.arguments = args
                 supportFragmentManager.beginTransaction()
                     .replace(R.id.container, fragment)
                     .commitNow()
             } else {
+                Log.i("Bool in main", it.toString())
                 val fragment = SignUpFragment()
                 fragment.arguments = args
                 supportFragmentManager.beginTransaction()

--- a/app/src/main/java/com/nokopi/marketregistersystem/NFCViewModel.kt
+++ b/app/src/main/java/com/nokopi/marketregistersystem/NFCViewModel.kt
@@ -1,6 +1,8 @@
 package com.nokopi.marketregistersystem
 
 import android.util.Log
+import androidx.lifecycle.LiveData
+import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.nokopi.marketregistersystem.data.UserDatabaseDao
@@ -8,16 +10,18 @@ import kotlinx.coroutines.launch
 
 class NFCViewModel(private val database: UserDatabaseDao): ViewModel() {
 
-    fun getUserIdResult(inputId: String): Boolean {
-        var getId = ""
-        viewModelScope.launch {
-            getId = getUserId(inputId)
-        }
-        Log.i("nfc2", inputId)
-        Log.i("getId", getId)
-        Log.i("Bool", (getId == inputId).toString())
+    private val _isNewUser = MutableLiveData<Boolean>()
+    val isNewUser: LiveData<Boolean>
+        get() = _isNewUser
 
-        return getId == inputId
+    fun getUserIdResult(inputId: String) {
+        viewModelScope.launch {
+            val getId = getUserId(inputId)
+            Log.i("nfc2", inputId)
+//            Log.i("getId in scope", getId)
+            Log.i("Bool", isNewUser.value.toString())
+            _isNewUser.value = getId == inputId
+        }
     }
 
     private suspend fun getUserId(inputId: String): String {


### PR DESCRIPTION
ViewModelでBoolを返す方式でRoomを非同期にしている都合上、データの取得が間に合わず常にfalseになってしまう問題が発覚しました。
そのため、ViewModel内に新規ユーザーかを監視する変数を追加し、その変数をMainで監視することで修正しました。