### PR TITLE
メモリリークの修正、ユーザー画面での戻るボタン無効化

### DIFF
--- a/app/src/main/java/com/nokopi/marketregistersystem/admin/AdminFragment.kt
+++ b/app/src/main/java/com/nokopi/marketregistersystem/admin/AdminFragment.kt
@@ -17,14 +17,15 @@ import com.nokopi.marketregistersystem.databinding.FragmentAdminBinding
 
 class AdminFragment : Fragment() {
 
-    private lateinit var binding: FragmentAdminBinding
+    private var _binding: FragmentAdminBinding? = null
+    private val binding get() = _binding!!
     private lateinit var viewModel: AdminViewModel
 
     override fun onCreateView(
         inflater: LayoutInflater, container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        binding = DataBindingUtil.inflate(inflater, R.layout.fragment_admin, container, false)
+        _binding = DataBindingUtil.inflate(inflater, R.layout.fragment_admin, container, false)
         binding.lifecycleOwner = viewLifecycleOwner
         viewModel = ViewModelProvider(this)[AdminViewModel::class.java]
         binding.adminViewModel = viewModel
@@ -77,6 +78,11 @@ class AdminFragment : Fragment() {
             }
         }
 
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
 }

--- a/app/src/main/java/com/nokopi/marketregistersystem/admin/AllUserFragment.kt
+++ b/app/src/main/java/com/nokopi/marketregistersystem/admin/AllUserFragment.kt
@@ -18,7 +18,8 @@ import com.nokopi.marketregistersystem.databinding.FragmentAllUserBinding
 
 class AllUserFragment : Fragment() {
 
-    private lateinit var binding: FragmentAllUserBinding
+    private var _binding: FragmentAllUserBinding? = null
+    private val binding get() = _binding!!
     private lateinit var viewModel: AllUserViewModel
 
     override fun onCreateView(
@@ -26,7 +27,7 @@ class AllUserFragment : Fragment() {
         savedInstanceState: Bundle?
     ): View {
 
-        binding = DataBindingUtil.inflate(inflater, R.layout.fragment_all_user, container, false)
+        _binding = DataBindingUtil.inflate(inflater, R.layout.fragment_all_user, container, false)
         binding.lifecycleOwner = viewLifecycleOwner
         val application = requireNotNull(this.activity).application
         val dataSource = UserDatabase.getInstance(application).userDatabaseDao
@@ -58,6 +59,11 @@ class AllUserFragment : Fragment() {
         binding.recyclerView.adapter = adapter
         binding.recyclerView.addItemDecoration(dividerItemDecoration)
 
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
 }

--- a/app/src/main/java/com/nokopi/marketregistersystem/admin/ProductFragment.kt
+++ b/app/src/main/java/com/nokopi/marketregistersystem/admin/ProductFragment.kt
@@ -18,7 +18,8 @@ import com.nokopi.marketregistersystem.dialog.AddProductDialogFragment
 
 class ProductFragment : Fragment(){
 
-    private lateinit var binding: FragmentProductBinding
+    private var _binding: FragmentProductBinding? = null
+    private val binding get() = _binding!!
     private lateinit var viewModel: ProductViewModel
     private lateinit var dialog: AddProductDialogFragment
 
@@ -28,7 +29,7 @@ class ProductFragment : Fragment(){
         savedInstanceState: Bundle?
     ): View {
 
-        binding = DataBindingUtil.inflate(inflater, R.layout.fragment_product, container, false)
+        _binding = DataBindingUtil.inflate(inflater, R.layout.fragment_product, container, false)
         binding.lifecycleOwner = viewLifecycleOwner
         val application = requireNotNull(this.activity).application
         val dataSource = ProductDatabase.getInstance(application).productDatabaseDao
@@ -64,6 +65,11 @@ class ProductFragment : Fragment(){
             dialog.show(childFragmentManager, "addProduct")
         }
 
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
 }

--- a/app/src/main/java/com/nokopi/marketregistersystem/admin/UserInfoFragment.kt
+++ b/app/src/main/java/com/nokopi/marketregistersystem/admin/UserInfoFragment.kt
@@ -17,7 +17,8 @@ import com.nokopi.marketregistersystem.dialog.ChangeBalanceDialogFragment
 
 class UserInfoFragment: Fragment() {
 
-    private lateinit var binding: FragmentUserInfoBinding
+    private var _binding: FragmentUserInfoBinding? = null
+    private val binding get() = _binding!!
     private lateinit var viewModel: UserInfoViewModel
     private val args: UserInfoFragmentArgs by navArgs()
     private lateinit var dialog: ChangeBalanceDialogFragment
@@ -28,7 +29,7 @@ class UserInfoFragment: Fragment() {
     ): View {
 
         val user = args.user
-        binding = DataBindingUtil.inflate(inflater, R.layout.fragment_user_info, container, false)
+        _binding = DataBindingUtil.inflate(inflater, R.layout.fragment_user_info, container, false)
         binding.lifecycleOwner = viewLifecycleOwner
         val application = requireNotNull(this.activity).application
         val dataSource = UserDatabase.getInstance(application).userDatabaseDao
@@ -73,6 +74,11 @@ class UserInfoFragment: Fragment() {
             }
         }
 
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
 }

--- a/app/src/main/java/com/nokopi/marketregistersystem/user/SignUpFragment.kt
+++ b/app/src/main/java/com/nokopi/marketregistersystem/user/SignUpFragment.kt
@@ -15,7 +15,8 @@ import com.nokopi.marketregistersystem.databinding.FragmentSignupBinding
 
 class SignUpFragment: Fragment() {
 
-    private lateinit var binding: FragmentSignupBinding
+    private var _binding: FragmentSignupBinding? = null
+    private val binding get() = _binding!!
     private lateinit var viewModel: SignUpViewModel
 
     override fun onCreateView(
@@ -24,7 +25,7 @@ class SignUpFragment: Fragment() {
         savedInstanceState: Bundle?
     ): View {
 
-        binding = DataBindingUtil.inflate(inflater, R.layout.fragment_signup, container, false)
+        _binding = DataBindingUtil.inflate(inflater, R.layout.fragment_signup, container, false)
         binding.lifecycleOwner = viewLifecycleOwner
         val inputId = requireArguments().getString("inputId") ?: "noId"
         val application = requireNotNull(this.activity).application
@@ -47,6 +48,11 @@ class SignUpFragment: Fragment() {
             }
         }
 
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
 }

--- a/app/src/main/java/com/nokopi/marketregistersystem/user/UserFragment.kt
+++ b/app/src/main/java/com/nokopi/marketregistersystem/user/UserFragment.kt
@@ -9,6 +9,7 @@ import androidx.appcompat.app.AlertDialog
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
 import androidx.lifecycle.ViewModelProvider
+import androidx.navigation.fragment.findNavController
 import com.nokopi.marketregistersystem.NFCActivity
 import com.nokopi.marketregistersystem.R
 import com.nokopi.marketregistersystem.data.UserDatabase
@@ -16,7 +17,8 @@ import com.nokopi.marketregistersystem.databinding.FragmentUserBinding
 
 class UserFragment: Fragment() {
 
-    private lateinit var binding: FragmentUserBinding
+    private var _binding: FragmentUserBinding? = null
+    private val binding get() = _binding!!
     private lateinit var viewModel: UserViewModel
     private var inputId = ""
 
@@ -25,7 +27,7 @@ class UserFragment: Fragment() {
         container: ViewGroup?,
         savedInstanceState: Bundle?
     ): View {
-        binding = DataBindingUtil.inflate(inflater, R.layout.fragment_user, container, false)
+        _binding = DataBindingUtil.inflate(inflater, R.layout.fragment_user, container, false)
         binding.lifecycleOwner = viewLifecycleOwner
         inputId = requireArguments().getString("inputId") ?: "noId"
         val application = requireNotNull(this.activity).application
@@ -60,6 +62,18 @@ class UserFragment: Fragment() {
             }
         }
 
+        viewModel.goPurchase.observe(viewLifecycleOwner) {
+            if (it) {
+                val action = UserFragmentDirections.actionUserFragmentToPurchaseFragment(inputId)
+                findNavController().navigate(action)
+            }
+        }
+
+    }
+
+    override fun onDestroyView() {
+        super.onDestroyView()
+        _binding = null
     }
 
 }

--- a/app/src/main/java/com/nokopi/marketregistersystem/user/UserFragment.kt
+++ b/app/src/main/java/com/nokopi/marketregistersystem/user/UserFragment.kt
@@ -5,6 +5,7 @@ import android.os.Bundle
 import android.view.LayoutInflater
 import android.view.View
 import android.view.ViewGroup
+import androidx.activity.addCallback
 import androidx.appcompat.app.AlertDialog
 import androidx.databinding.DataBindingUtil
 import androidx.fragment.app.Fragment
@@ -35,6 +36,9 @@ class UserFragment: Fragment() {
         val viewModelFactory = UserViewModelFactory(dataSource, inputId)
         viewModel = ViewModelProvider(this, viewModelFactory)[UserViewModel::class.java]
         binding.userViewModel= viewModel
+
+        // This callback will only be called when MyFragment is at least Started.
+        val callback = requireActivity().onBackPressedDispatcher.addCallback(viewLifecycleOwner) { }
 
         return binding.root
     }


### PR DESCRIPTION
メモリリークが発生する可能性があったため、bindingの宣言方法をviewBindingを参考にし、変更しました。
購入後に遷移した先のユーザー画面で戻るボタンを押した場合、購入画面に戻ってしまっていたため、戻るボタンを無効化しました。